### PR TITLE
Swap wrtc for node-datachannel

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -1,8 +1,8 @@
 const createTorrent = require('create-torrent')
-const wrtc = require('wrtc')
+const nodeDataChannel = require('node-datachannel')
 
 global.WEBTORRENT_ANNOUNCE = createTorrent.announceList
   .map(arr => arr[0])
   .filter(url => url.indexOf('wss://') === 0 || url.indexOf('ws://') === 0)
 
-global.WRTC = wrtc
+global.WRTC = nodeDataChannel

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "create-torrent": "^4.4.2",
     "webtorrent": ">=0.111.0",
     "webtorrent-cli": "^3.2.0",
-    "wrtc": "^0.4.6"
+    "node-datachannel": "^0.0.18"
   },
   "devDependencies": {
     "standard": "*"


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

* [ ] Documentation update
* [ ] Bug fix
* [ ] New feature
* [x] Other, please explain: Library swap, see #118

**What changes did you make? (Give an overview)**

Swapped `wrtc` for `node-datachannel`

**Which issue (if any) does this pull request address?**

Fixes #118. And [this comment](https://github.com/webtorrent/webtorrent-hybrid/issues/120#issuecomment-740411979) of a user reporting better results.

> An update: as per #118 we tried to replace wrtc with node-datachannel. As a result, the CPU usage is solved.

Also requested by @feross [here](https://github.com/webtorrent/webtorrent-hybrid/issues/119#issuecomment-733938401).

**Is there anything you'd like reviewers to focus on?**

Code is untested.

The change is minor and presented so everyone can run it and compare the results on their machines to help support the decision to swap or keep `wrtc`.

It's really tiny, so let's make it easy to make WebTorrent better.