### PR TITLE
fix: webrtc import

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -1,5 +1,5 @@
 import { announceList } from 'create-torrent'
-import * as wrtc from 'wrtc'
+import wrtc from 'wrtc'
 
 globalThis.WEBTORRENT_ANNOUNCE = announceList
   .map(arr => arr[0])


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The recent esm update changed the structure of the resulting wrtc object, this breaks web peers in webtorrent-hybrid.

I found that this change makes simple-peer fail on this line:
https://github.com/feross/simple-peer/blob/master/index.js#L101

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
