### PR TITLE
fixes mac-m1 compilation for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+
+services:
+  app:
+    build: .
+    ports:
+      - published: 8000
+        target: 8000
+    # Necessary to run on Mac OS X since electron dependency does not
+    # have arm64 support and will fail to compile.
+    platform: "linux/amd64"


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added a docker-compose file which contains a platform directive to force the image to be compiled using the x86-64 chipset. Without this, the build will fail on mac-m1's when it tries to fetch the electron dependency for the m1 platform. This is a known problem that does not have a work around yet.

**Is there anything you'd like reviewers to focus on?**

Should be very straightforward.